### PR TITLE
Reduce MSBuild reference

### DIFF
--- a/Task/Task.csproj
+++ b/Task/Task.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="16.5.0" />
+    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="16.5.0" ExcludeAssets="runtime" PrivateAssets="all" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Since this is a task assembly, it needs to access MSBuild types at compile time but will get them from the running engine at runtime, so we can exclude runtime assets for the MSBuild package.

Setting PrivateAssets does nothing in this repo but is required if a task is packaged, so it's a good idea to set it here too.

Suggested by @Lakritzator in https://github.com/greenshot/greenshot/pull/358#issuecomment-1298404788. Thanks!